### PR TITLE
HTTPS-insecure-skip

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,8 +115,8 @@ func main() {
 			},
 		}
 		// Install the custom Client for HTTP(s) URLs
-		client.InstallProtocol("https", githttp.NewClient(customClient))
-		client.InstallProtocol("http", githttp.NewClient(customClient))
+		clientT.InstallProtocol("https", githttp.NewClient(customClient))
+		clientT.InstallProtocol("http", githttp.NewClient(customClient))
 		
 		g, err := git.PlainClone(repoPath, false, &git.CloneOptions{
 			URL: repoURL,

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	"net/http"
 
 	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing/transport/client"
+	clientT"github.com/go-git/go-git/v5/plumbing/transport/client"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"gopkg.in/yaml.v2"
 	certificatesv1 "k8s.io/api/certificates/v1"

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func main() {
 		// Create custom HTTP client that skips TLS verification
 		customClient := &http.Client{
 		  	Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			},
 		}
 		// Install the custom Client for HTTP(s) URLs

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"crypto/tls"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -15,6 +16,8 @@ import (
 	"net/http"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/transport/client"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"gopkg.in/yaml.v2"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	"net/http"
 
 	"github.com/go-git/go-git/v5"
-	clientT"github.com/go-git/go-git/v5/plumbing/transport/client"
+	clientT "github.com/go-git/go-git/v5/plumbing/transport/client"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"gopkg.in/yaml.v2"
 	certificatesv1 "k8s.io/api/certificates/v1"

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+	"net/http"
 
 	"github.com/go-git/go-git/v5"
 	"gopkg.in/yaml.v2"
@@ -104,6 +105,16 @@ func main() {
 	fmt.Printf("RepoPath: %v", repoPath)
 	fmt.Printf("RepoURL: %v", repoURL)
 	if _, err := os.Stat(repoPath); os.IsNotExist(err) {
+		// Create custom HTTP client that skips TLS verification
+		customClient := &http.Client{
+		  	Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}
+			},
+		}
+		// Install the custom Client for HTTP(s) URLs
+		client.InstallProtocol("https", githttp.NewClient(customClient))
+		client.InstallProtocol("http", githttp.NewClient(customClient))
+		
 		g, err := git.PlainClone(repoPath, false, &git.CloneOptions{
 			URL: repoURL,
 		})


### PR DESCRIPTION
// Create custom HTTP client that skips TLS verification
		customClient := &http.Client{
			Transport: &http.Transport{
				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
			},
		}

		// Install the custom client for HTTP(S) URLs
		client.InstallProtocol("https", githttp.NewClient(customClient))
		client.InstallProtocol("http", githttp.NewClient(customClient))